### PR TITLE
handle the situation where the bot was not directly mentioned, in order

### DIFF
--- a/Lesson 2/handler.js
+++ b/Lesson 2/handler.js
@@ -42,5 +42,9 @@ module.exports.endpoint = (event, context, callback) => {
 
       callback(null, {statusCode: 200});
     }) 
+  } else {
+    // if Slack does not receive an HTTP 2xx within 3 seconds, it will retry 3 times using
+    // exponential backoff, so just return a 200 if the bot was not directly mentioned
+      callback(null, {statusCode: 200});
   }
 };


### PR DESCRIPTION
to not have Slack think there was no 2xx response and keep
retrying/calling the function